### PR TITLE
Grids and stuff

### DIFF
--- a/src/SpatialGrids.jl
+++ b/src/SpatialGrids.jl
@@ -5,7 +5,7 @@ module SpatialGrids
 using StaticArrays
 
 export Raster, rasterize_points
-export SparseVoxelGrid, in_cuboid, voxel_center
+export SparseVoxelGrid, in_cuboid, voxel_center, make_voxel_id
 
 include("raster.jl")
 include("sparse_voxels.jl")

--- a/src/raster.jl
+++ b/src/raster.jl
@@ -1,5 +1,3 @@
-using StaticArrays
-
 """
     rasterize_points(points, dx::AbstractFloat)
 
@@ -46,7 +44,7 @@ end
 """
 `rasterize_points{T <: AbstractVector}(points::Vector{T}, dx::AbstractFloat) -> Raster`
 
-Returns `Raster` of  points `pos` with quadratic cellsize `dx`
+Returns a `Raster` of `points` with quadratic cellsize `dx`.
 """
 function rasterize_points{T <: AbstractVector}(points::Vector{T}, dx::AbstractFloat)
     (xmin, xmax, ymin, ymax) = bounds(points)

--- a/src/sparse_voxels.jl
+++ b/src/sparse_voxels.jl
@@ -1,5 +1,3 @@
-using StaticArrays
-
 const VoxelId = NTuple{3, Int}
 
 """
@@ -34,16 +32,14 @@ for voxel in grid
 end
 ```
 """
-immutable SparseVoxelGrid{T <: Number}
+immutable SparseVoxelGrid{T <: Real}
     voxel_size::SVector{3, T}
     voxel_info::Dict{VoxelId, UnitRange{Int}}
     point_indices::Vector{Int}
 end
 
-function SparseVoxelGrid{T <: AbstractVector}(points::Vector{T}, voxel_size)
-    voxel_size = get_voxel_size(voxel_size)
+function SparseVoxelGrid{T1 <: AbstractVector, T2 <: Real}(points::Vector{T1}, voxel_size::SVector{3, T2})
     npoints = length(points)
-    # ndims != 3 && throw(ArgumentError("Points dimensions are $(size(points)), should be a 3xN matrix."))
 
     # In order to avoid allocating a vector for each voxel, we construct the data structure in a backward-looking order.
 
@@ -62,8 +58,9 @@ function SparseVoxelGrid{T <: AbstractVector}(points::Vector{T}, voxel_size)
     # Allocate ranges for the indices of points in each voxel based on the counts
     voxel_info = Dict{VoxelId, UnitRange{Int}}()
     current_index = 1
-    for (group_id, group_size) in group_counts
-        voxel_info[group_id] = current_index:current_index+group_size-1
+    for group_id in keys(group_counts)
+        group_size = group_counts[group_id]
+        voxel_info[group_id] = UnitRange(current_index, current_index+group_size-1)
         current_index += group_size
     end
 
@@ -79,24 +76,25 @@ function SparseVoxelGrid{T <: AbstractVector}(points::Vector{T}, voxel_size)
     return SparseVoxelGrid(voxel_size, voxel_info, point_indices)
 end
 
-# Convert matrix to Vector{SVector}
-function SparseVoxelGrid{T <: Number}(points::Matrix{T}, voxel_size)
-    ndim = size(points, 1)
+function SparseVoxelGrid{T1 <: Real, T2 <: Real}(points::Matrix{T1}, voxel_size::SVector{3, T2})
     npoints = size(points, 2)
-    if isbits(T)
-        new_data = reinterpret(SVector{ndim, T}, points, (length(points) ÷ ndim, ))
-    else
-        new_data = SVector{ndim, T}[SVector{ndim, T}(points[:, i]) for i in 1:npoints]
-    end
+    new_data = Vector{SVector{3, T1}}()
+    new_data = reinterpret(SVector{3, T1}, points, (length(points) ÷ 3, ))
     SparseVoxelGrid(new_data, voxel_size)
 end
 
-function get_voxel_size{T <: Number}(voxel_size::T)
-    SVector{3, T}(voxel_size, voxel_size, voxel_size)
+function SparseVoxelGrid{T1 <: Real, T2 <: Real}(points::Matrix{T1}, voxel_size::T2)
+    voxel_size_vector = get_voxel_size(voxel_size)
+    SparseVoxelGrid(points, voxel_size_vector)
 end
 
-function get_voxel_size{T <: Number}(voxel_size::NTuple{3, T})
-    SVector{3, T}(voxel_size)
+function SparseVoxelGrid{T1 <: AbstractVector, T2 <: Real}(points::Vector{T1}, voxel_size::T2)
+    voxel_size_vector = get_voxel_size(voxel_size)
+    SparseVoxelGrid(points, voxel_size_vector)
+end
+
+function get_voxel_size{T <: Real}(voxel_size::T)
+    SVector{3, T}(voxel_size, voxel_size, voxel_size)
 end
 
 Base.length(grid::SparseVoxelGrid) = length(grid.voxel_info)
@@ -110,16 +108,14 @@ function Base.show(io::IO, grid::SparseVoxelGrid)
 end
 
 """
-    make_voxel_id(points::Matrix, index, voxel_size)
+    make_voxel_id(point::AbstractVector, voxel_size::SVector{3,AbstractFloat})
 
-Create a 3D voxel id tuple for the point specified by the column index.
+Create the voxel id for a given point and voxel size.
 """
-function make_voxel_id(points::AbstractVector, voxel_size::SVector)
-    (floor(Int, points[1] / voxel_size[1]), floor(Int, points[2] / voxel_size[2]),
-     floor(Int, points[3] / voxel_size[3]))
+@inline function make_voxel_id{T <: AbstractFloat}(point::AbstractVector, voxel_size::SVector{3, T})
+    (floor(Int, point[1] / voxel_size[1]), floor(Int, point[2] / voxel_size[2]),
+     floor(Int, point[3] / voxel_size[3]))
 end
-
-
 
 "An iterator type to return point indices in a voxel. See SparseVoxelGrid() for usage."
 immutable Voxel
@@ -146,13 +142,12 @@ function Base.next(v::Voxel, state)
     v.all_point_indices[v.point_index_range[state]], state + 1
 end
 Base.done(v::Voxel, state) = state > length(v.point_index_range)
+
 Base.eltype(::Voxel) = Int
 Base.length(v::Voxel) = length(v.point_index_range)
 function Base.show(io::IO, v::Voxel)
     print(io, typeof(v), " ", v.id, " with ", length(v.point_index_range), " points")
 end
-
-
 
 "Voxel iterator that returns the `Voxel`s. See `in_cuboid()` for usage."
 immutable VoxelCuboid
@@ -262,6 +257,6 @@ end
 
 Calculate the centre point for the `voxel_id` in the spatial grid.
 """
-function voxel_center(grid::SparseVoxelGrid, voxel_id::VoxelId)
+@inline function voxel_center(grid::SparseVoxelGrid, voxel_id::VoxelId)
     center = SVector{3, Float64}(voxel_id) .* grid.voxel_size - grid.voxel_size * 0.5
 end

--- a/src/sparse_voxels.jl
+++ b/src/sparse_voxels.jl
@@ -112,7 +112,7 @@ end
 
 Create the voxel id for a given point and voxel size.
 """
-@inline function make_voxel_id{T <: AbstractFloat}(point::AbstractVector, voxel_size::SVector{3, T})
+@inline function make_voxel_id{T <: Real}(point::AbstractVector, voxel_size::SVector{3, T})
     (floor(Int, point[1] / voxel_size[1]), floor(Int, point[2] / voxel_size[2]),
      floor(Int, point[3] / voxel_size[3]))
 end

--- a/test/spatial_grid_test.jl
+++ b/test/spatial_grid_test.jl
@@ -42,6 +42,9 @@
         vector_points = [SVector{3, Float64}(points3d[:,i]) for i = 1:size(points3d, 2)]
         grid = SparseVoxelGrid(vector_points, SVector(1, 1, 1))
         @test length(grid) == 27
+
+        grid = SparseVoxelGrid(vector_points, 2.0)
+        @test length(grid) == 8
     end
 
     @testset "Neighbouring voxel" begin

--- a/test/spatial_grid_test.jl
+++ b/test/spatial_grid_test.jl
@@ -32,7 +32,7 @@
         @test length(collect(SparseVoxelGrid(points3d, SVector(2.0, 2.5, 4.0)))) == 4
 
         vector_points = [SVector{3, Float64}(points3d[:,i]) for i = 1:size(points3d, 2)]
-        grid = SparseVoxelGrid(vector_points, SVector(1.0, 1.0, 1.0))
+        grid = SparseVoxelGrid(vector_points, SVector(1, 1, 1))
         @test length(grid) == 27
     end
 

--- a/test/spatial_grid_test.jl
+++ b/test/spatial_grid_test.jl
@@ -29,7 +29,11 @@
         @test length(collect(grid)) == 27
         [@test length(collect(voxel)) == 1 for voxel in grid]
         @test voxel_center(grid, (1, 1, 1)) == SVector{3,Float64}(0.5, 0.5, 0.5)
-        @test length(collect(SparseVoxelGrid(points3d, (2.0, 2.5, 4.0)))) == 4
+        @test length(collect(SparseVoxelGrid(points3d, SVector(2.0, 2.5, 4.0)))) == 4
+
+        vector_points = [SVector{3, Float64}(points3d[:,i]) for i = 1:size(points3d, 2)]
+        grid = SparseVoxelGrid(vector_points, SVector(1.0, 1.0, 1.0))
+        @test length(grid) == 27
     end
 
     @testset "Neighbouring voxel" begin

--- a/test/spatial_grid_test.jl
+++ b/test/spatial_grid_test.jl
@@ -38,6 +38,7 @@
         [@test length(collect(voxel)) == 1 for voxel in grid]
         @test voxel_center(grid, (1, 1, 1)) == SVector{3,Float64}(0.5, 0.5, 0.5)
         @test length(collect(SparseVoxelGrid(points3d, (2.0, 2.5, 4.0)))) == 4
+        @test length(collect(SparseVoxelGrid(points3d, SVector(2.0, 2.5, 4.0)))) == 4
 
         vector_points = [SVector{3, Float64}(points3d[:,i]) for i = 1:size(points3d, 2)]
         grid = SparseVoxelGrid(vector_points, SVector(1, 1, 1))

--- a/test/spatial_grid_test.jl
+++ b/test/spatial_grid_test.jl
@@ -17,6 +17,14 @@
         [@test length(r) == 3 for r in values(d2d)]
         d3d = rasterize_points(points3d, 1.0)
         [@test length(r) == 3 for r in values(d3d)]
+
+        @test length(keys(d2d)) == 9
+        @test d2d[(0x00000000,0x00000000)] == UInt32[1, 2, 3]
+
+        @test_throws DimensionMismatch rasterize_points([SVector{4, Float32}(rand(4)) for i= 1:4], 1.0)
+
+        io = IOBuffer()
+        show(io, d3d)
     end
 
     @testset "Voxelization" begin
@@ -29,7 +37,7 @@
         @test length(collect(grid)) == 27
         [@test length(collect(voxel)) == 1 for voxel in grid]
         @test voxel_center(grid, (1, 1, 1)) == SVector{3,Float64}(0.5, 0.5, 0.5)
-        @test length(collect(SparseVoxelGrid(points3d, SVector(2.0, 2.5, 4.0)))) == 4
+        @test length(collect(SparseVoxelGrid(points3d, (2.0, 2.5, 4.0)))) == 4
 
         vector_points = [SVector{3, Float64}(points3d[:,i]) for i = 1:size(points3d, 2)]
         grid = SparseVoxelGrid(vector_points, SVector(1, 1, 1))


### PR DESCRIPTION
Small tweaks.

* `code_warntype` was showing that `(a,b) in Dict` it didn't know the types of `a` and `b`. Hence, changed line below to `for group_id in keys(group_counts)`
* Remove `Tuple` as input for `voxel_size`. Accept either `Float` or a `SVector`.